### PR TITLE
Simplify integration tests to remove the need for adding test instance classes for each example instance under each solver implementation.

### DIFF
--- a/cplex-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITCplexKnapsackSolverSampleTest.kt
+++ b/cplex-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITCplexKnapsackSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITCplexKnapsackSolverSampleTest : KnapsackSolverSample()

--- a/cplex-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITCplexPrimitiveSolverSampleTest.kt
+++ b/cplex-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITCplexPrimitiveSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITCplexPrimitiveSolverSampleTest : PrimitiveSolverSample()

--- a/cplex-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITCplexSudokuSolverSampleTest.kt
+++ b/cplex-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITCplexSudokuSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITCplexSudokuSolverSampleTest : SudokuSolverSample()

--- a/cplex-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITCplexTravellingSalesmanSolverSampleTest.kt
+++ b/cplex-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITCplexTravellingSalesmanSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITCplexTravellingSalesmanSolverSampleTest : TravellingSalesmanSolverSample()

--- a/cplex-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
+++ b/cplex-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
@@ -1,0 +1,3 @@
+package io.github.mohitc.lpsolver.test
+
+class ITSolverTest : SolverTest()

--- a/glpk-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGlpkKnapsackSolverSampleTest.kt
+++ b/glpk-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGlpkKnapsackSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITGlpkKnapsackSolverSampleTest : KnapsackSolverSample()

--- a/glpk-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGlpkSudokuSolverSampleTest.kt
+++ b/glpk-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGlpkSudokuSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITGlpkSudokuSolverSampleTest : SudokuSolverSample()

--- a/glpk-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGlpkTravellingSalesmanSolverSampleTest.kt
+++ b/glpk-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGlpkTravellingSalesmanSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITGlpkTravellingSalesmanSolverSampleTest : TravellingSalesmanSolverSample()

--- a/glpk-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGplkPrimitiveSolverSampleTest.kt
+++ b/glpk-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGplkPrimitiveSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITGplkPrimitiveSolverSampleTest : PrimitiveSolverSample()

--- a/glpk-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
+++ b/glpk-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
@@ -1,0 +1,3 @@
+package io.github.mohitc.lpsolver.test
+
+class ITSolverTest : SolverTest()

--- a/gurobi-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGurobiKnapsackSolverSampleTest.kt
+++ b/gurobi-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGurobiKnapsackSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITGurobiKnapsackSolverSampleTest : KnapsackSolverSample()

--- a/gurobi-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGurobiPrimitiveSolverSampleTest.kt
+++ b/gurobi-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGurobiPrimitiveSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITGurobiPrimitiveSolverSampleTest : PrimitiveSolverSample()

--- a/gurobi-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGurobiSudokuSolverSampleTest.kt
+++ b/gurobi-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGurobiSudokuSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITGurobiSudokuSolverSampleTest : SudokuSolverSample()

--- a/gurobi-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGurobiTravellingSalesmanSolverSampleTest.kt
+++ b/gurobi-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITGurobiTravellingSalesmanSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITGurobiTravellingSalesmanSolverSampleTest : TravellingSalesmanSolverSample()

--- a/gurobi-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
+++ b/gurobi-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
@@ -1,0 +1,3 @@
+package io.github.mohitc.lpsolver.test
+
+class ITSolverTest : SolverTest()

--- a/highs-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITHighsKnapsackSolverSampleTest.kt
+++ b/highs-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITHighsKnapsackSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITHighsKnapsackSolverSampleTest : KnapsackSolverSample()

--- a/highs-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITHighsPrimitiveSolverSampleTest.kt
+++ b/highs-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITHighsPrimitiveSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITHighsPrimitiveSolverSampleTest : PrimitiveSolverSample()

--- a/highs-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITHighsSudokuSolverSampleTest.kt
+++ b/highs-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITHighsSudokuSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITHighsSudokuSolverSampleTest : SudokuSolverSample()

--- a/highs-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITHighsTravellingSalesmanSolverSampleTest.kt
+++ b/highs-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITHighsTravellingSalesmanSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITHighsTravellingSalesmanSolverSampleTest : TravellingSalesmanSolverSample()

--- a/highs-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
+++ b/highs-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
@@ -1,0 +1,3 @@
+package io.github.mohitc.lpsolver.test
+
+class ITSolverTest : SolverTest()

--- a/lp-api/src/test/kotlin/io/github/mohitc/lpapi/model/LPModelValidationTest.kt
+++ b/lp-api/src/test/kotlin/io/github/mohitc/lpapi/model/LPModelValidationTest.kt
@@ -91,6 +91,21 @@ class LPModelValidationTest {
       "Integer bounding should pass if variables have at least one " +
         "integer value between their bounds",
     )
+
+    lpModel = LPModel("testModel")
+    lpModel.variables.add(LPVar("a", LPVarType.INTEGER, 1.9, 1.95))
+    Assertions.assertFalse(
+      lpModel.validate(),
+      "Integer bounding should not pass if variables do not have at least one " +
+        "integer value between their bounds",
+    )
+
+    lpModel = LPModel("testModel")
+    lpModel.variables.add(LPVar("a", LPVarType.INTEGER, 1.0, 1.0))
+    Assertions.assertTrue(
+      lpModel.validate(),
+      "Integer bounding should pass if bounds are equal and the same as an int",
+    )
   }
 
   @Test

--- a/lp-rw/pom.xml
+++ b/lp-rw/pom.xml
@@ -27,13 +27,6 @@
       <artifactId>lp-api</artifactId>
       <version>${revision}</version>
     </dependency>
-    <!--LP Solver samples to test import / export to file -->
-    <dependency>
-      <groupId>io.github.mohitc</groupId>
-      <artifactId>lp-solver-sample</artifactId>
-      <version>${revision}</version>
-      <scope>test</scope>
-    </dependency>
     <!--Jackson dependencies for parsing to YAML/JSON-->
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>

--- a/lp-solver-sample/README.md
+++ b/lp-solver-sample/README.md
@@ -1,9 +1,32 @@
-# Example LPModel Instances
+# Example Instances
 
-This package contains some example `LPModel` instances, which are also used
-internally in running some validation tests for the different solvers.
+This package contains some examples for modeling MILP problems, and are also
+used for integration tests for the various solvers supported in this framework.
+
+Currently supported instances include:
 
 * [
   `PrimitiveSolverSample`](src/main/kotlin/io/github/mohitc/lpsolver/sample/PrimitiveSolverSample.kt)
   is a very simple model useful for demonstrating the mechanism to build and
   solver models.
+* [
+  `SudokuSolverSample`](src/main/kotlin/io/github/mohitc/lpsolver/sample/SudokuSolverSample.kt)
+  implements and solves a 9x9 Sudoku using ILP modeling, and is an example of a
+  feasibility problem.
+* [
+  `KnapsackSolverSample`](src/main/kotlin/io/github/mohitc/lpsolver/sample/KnapsackSolverSample.kt)
+  implements and solves the classic Knapsack problem.
+* [
+  `TravellingSalesmanSolverSample`](src/main/kotlin/io/github/mohitc/lpsolver/sample/TravellingSalesmanSolverSample.kt)
+  generates a random instance of the Travelling Salesman problem, solves it
+  using dynamic programming and via ILP formulation and validates that the
+  solutions are equivalent.
+
+In order to have the problems supported in integration tests, all problems
+implement the [
+`SolverTestInstance`](src/main/kotlin/io/github/mohitc/lpsolver/test/SolverTestInstance.kt)
+Interface and are included in the [
+`SolverTest`](src/main/kotlin/io/github/mohitc/lpsolver/test/SolverTest.kt)
+class to be included in all existing solver tests. Samples of integration tests
+for the various solvers can be found in the `ITSolverTest` classes under the
+various solver implementations.

--- a/lp-solver-sample/src/main/kotlin/io/github/mohitc/lpsolver/sample/PrimitiveSolverSample.kt
+++ b/lp-solver-sample/src/main/kotlin/io/github/mohitc/lpsolver/sample/PrimitiveSolverSample.kt
@@ -9,92 +9,71 @@ import io.github.mohitc.lpapi.model.enums.LPOperator
 import io.github.mohitc.lpapi.model.enums.LPSolutionStatus
 import io.github.mohitc.lpapi.model.enums.LPVarType
 import io.github.mohitc.lpsolver.spi.Solver
-import mu.KotlinLogging
+import io.github.mohitc.lpsolver.test.SolverTestInstance
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Test
 import kotlin.math.abs
 
-open class PrimitiveSolverSample {
-  private val log = KotlinLogging.logger(this.javaClass.simpleName)
+class PrimitiveSolverSample : SolverTestInstance {
+  var model: LPModel? = null
 
-  val modelGenerator: () -> LPModel = {
-    val model = LPModel("Test Instance")
-    // Initializing variables
-    model.variables.add(LPVar("X", LPVarType.BOOLEAN))
-    model.variables.add(LPVar("Y", LPVarType.BOOLEAN))
-    model.variables.add(LPVar("Z", LPVarType.BOOLEAN))
+  override fun name(): String = "Primitive Model"
 
-    // Objective function => Maximize : X + Y + 2Z
-    model.objective.expression
-      .addTerm("X")
-      .addTerm("Y")
-      .addTerm(2, "Z")
-    model.objective.objective = LPObjectiveType.MAXIMIZE
+  override fun initModel(): Boolean {
+    val localModel =
+      LPModel("Test Instance").apply {
+        // Initializing variables
+        variables.add(LPVar("X", LPVarType.BOOLEAN))
+        variables.add(LPVar("Y", LPVarType.BOOLEAN))
+        variables.add(LPVar("Z", LPVarType.BOOLEAN))
 
-    // Add constants
-    // a = 1, b = 2, c = 3
-    model.constants.add(LPConstant("a", 1))
-    model.constants.add(LPConstant("b", 2))
-    model.constants.add(LPConstant("c", 3))
+        // Objective function => Maximize : X + Y + 2Z
+        objective.expression
+          .addTerm("X")
+          .addTerm("Y")
+          .addTerm(2, "Z")
+        objective.objective = LPObjectiveType.MAXIMIZE
 
-    // Add Constraints
-    // Constraint 1 : aX + bY + cZ <= 4
-    val constraint1 = model.constraints.add(LPConstraint("Constraint 1"))
-    constraint1
-      ?.lhs
-      ?.addTerm("a", "X")
-      ?.addTerm("b", "Y")
-      ?.addTerm("c", "Z")
-    constraint1?.rhs?.add(4)
-    constraint1?.operator = LPOperator.LESS_EQUAL
+        // Add constants
+        // a = 1, b = 2, c = 3
+        constants.add(LPConstant("a", 1))
+        constants.add(LPConstant("b", 2))
+        constants.add(LPConstant("c", 3))
 
-    // Constraint 2 : X + Y >= 2
-    val constraint2 = model.constraints.add(LPConstraint("Constraint 2"))
-    constraint2
-      ?.lhs
-      ?.addTerm("X")
-      ?.addTerm("Y")
-    constraint2?.rhs?.add(2)
-    constraint2?.operator = LPOperator.GREATER_EQUAL
+        // Add Constraints
+        // Constraint 1 : aX + bY + cZ <= 4
+        val constraint1 = constraints.add(LPConstraint("Constraint 1"))
+        constraint1
+          ?.lhs
+          ?.addTerm("a", "X")
+          ?.addTerm("b", "Y")
+          ?.addTerm("c", "Z")
+        constraint1?.rhs?.add(4)
+        constraint1?.operator = LPOperator.LESS_EQUAL
 
-    model
-  }
-
-  val model: LPModel = modelGenerator()
-
-  @Test
-  fun validateModel() {
-    assertTrue(model.validate(), "Model Validation failed in the primitive solver")
+        // Constraint 2 : X + Y >= 2
+        val constraint2 = constraints.add(LPConstraint("Constraint 2"))
+        constraint2
+          ?.lhs
+          ?.addTerm("X")
+          ?.addTerm("Y")
+        constraint2?.rhs?.add(2)
+        constraint2?.operator = LPOperator.GREATER_EQUAL
+      }
+    model = localModel
+    return localModel.validate()
   }
 
   /** Function to be implemented in the specific solvers. Function takes in a model, solves it, and provides a model
    * with the results set */
-  open fun initAndSolveModel(model: LPModel): LPModel? {
-    val solver = Solver.create(model)
+  override fun solveAndValidate() {
+    val solver = Solver.create(model!!)
     solver.initialize()
     val status = solver.solve()
-    return if (status != LPSolutionStatus.UNKNOWN &&
-      status != LPSolutionStatus.INFEASIBLE &&
-      status != LPSolutionStatus.INFEASIBLE_OR_UNBOUNDED
-    ) {
-      solver.model
-    } else {
-      null
-    }
-  }
-
-  /**Test function that validates the results computed by the model*/
-  @Test
-  fun testSolver() {
-    val model = initAndSolveModel(model)
-    log.info { model?.solution }
-    assertNotNull(model, "Model should be computed successfully.")
+    assertEquals(status, LPSolutionStatus.OPTIMAL, "Expect optimal result")
     assertEquals(model?.variables?.get("X")?.result, 1, "X should be = 1")
     assertEquals(model?.variables?.get("Y")?.result, 1, "Y should be = 1")
     assertEquals(model?.variables?.get("Z")?.result, 0, "Z should be = 0")
-    assertEquals(model?.solution?.status, LPSolutionStatus.OPTIMAL, "Expect optimal result")
     assertTrue(abs(model?.solution?.objective!! - 2) < 0.001, "Objective value for optimal result should be 2.0")
   }
 }

--- a/lp-solver-sample/src/main/kotlin/io/github/mohitc/lpsolver/sample/SudokuSolverSample.kt
+++ b/lp-solver-sample/src/main/kotlin/io/github/mohitc/lpsolver/sample/SudokuSolverSample.kt
@@ -7,12 +7,16 @@ import io.github.mohitc.lpapi.model.enums.LPOperator
 import io.github.mohitc.lpapi.model.enums.LPSolutionStatus
 import io.github.mohitc.lpapi.model.enums.LPVarType
 import io.github.mohitc.lpsolver.spi.Solver
+import io.github.mohitc.lpsolver.test.SolverTestInstance
 import mu.KotlinLogging
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Test
 
-open class SudokuSolverSample {
+class SudokuSolverSample : SolverTestInstance {
   private val log = KotlinLogging.logger(this.javaClass.simpleName)
+
+  private var model: LPModel? = null
+
+  override fun name(): String = "Sudoku Solver"
 
   private fun varName(
     fieldVal: Int,
@@ -90,9 +94,8 @@ open class SudokuSolverSample {
     return model
   }
 
-  @Test
-  fun testSolveFeasibleProblem() {
-    val model = baseModelGenerator()
+  override fun initModel(): Boolean {
+    val m = baseModelGenerator()
     // Initialize feasible sudoku problem instance
     // __|_1_2_3_4_5_6_7_8_9
     // 1 | - 5 - 8 - - - - 6
@@ -129,14 +132,20 @@ open class SudokuSolverSample {
       varName(4, 9, 8),
       varName(3, 2, 9),
       varName(8, 5, 9),
-    ).mapNotNull { v -> model.variables.get(v) }.forEach { v ->
+    ).mapNotNull { v -> m.variables.get(v) }.forEach { v ->
       v.bounds(1.0, 1.0)
     }
+
+    model = m
+    return m.validate()
+  }
+
+  override fun solveAndValidate() {
     log.info { "Initializing the solver " }
-    val solver = Solver.create(model)
+    val solver = Solver.create(model!!)
     solver.initialize()
     val status = solver.solve()
-    log.info { model.solution }
+    log.info { model!!.solution }
     assertEquals(status, LPSolutionStatus.OPTIMAL, "model should be solved successfully")
   }
 }

--- a/lp-solver-sample/src/main/kotlin/io/github/mohitc/lpsolver/test/SolverTest.kt
+++ b/lp-solver-sample/src/main/kotlin/io/github/mohitc/lpsolver/test/SolverTest.kt
@@ -1,0 +1,46 @@
+package io.github.mohitc.lpsolver.test
+
+import io.github.mohitc.lpsolver.sample.KnapsackSolverSample
+import io.github.mohitc.lpsolver.sample.PrimitiveSolverSample
+import io.github.mohitc.lpsolver.sample.SudokuSolverSample
+import io.github.mohitc.lpsolver.sample.TravellingSalesmanSolverSample
+import mu.KotlinLogging
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+open class SolverTest {
+  private val log = KotlinLogging.logger(this.javaClass.simpleName)
+
+  private val testInstances: List<SolverTestInstance> =
+    listOf(
+      PrimitiveSolverSample(),
+      KnapsackSolverSample(),
+      SudokuSolverSample(),
+      TravellingSalesmanSolverSample(),
+    )
+
+  private fun testArgs() =
+    testInstances
+      .map {
+        Arguments.of(
+          it.name(),
+          it,
+        )
+      }.toList()
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("testArgs")
+  fun testModels(
+    name: String,
+    ti: SolverTestInstance,
+  ) {
+    log.info { "Testing model $name" }
+    assertTrue(ti.initModel(), "initModel() want true got false")
+    log.info { "Starting Solver and Validations for $name" }
+    ti.solveAndValidate()
+  }
+}

--- a/lp-solver-sample/src/main/kotlin/io/github/mohitc/lpsolver/test/SolverTestInstance.kt
+++ b/lp-solver-sample/src/main/kotlin/io/github/mohitc/lpsolver/test/SolverTestInstance.kt
@@ -1,0 +1,9 @@
+package io.github.mohitc.lpsolver.test
+
+interface SolverTestInstance {
+  fun name(): String
+
+  fun initModel(): Boolean
+
+  fun solveAndValidate()
+}

--- a/ojalgo-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITOjalgoKnapsackSolverSampleTest.kt
+++ b/ojalgo-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITOjalgoKnapsackSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITOjalgoKnapsackSolverSampleTest : KnapsackSolverSample()

--- a/ojalgo-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITOjalgoPrimitiveSolverSampleTest.kt
+++ b/ojalgo-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITOjalgoPrimitiveSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITOjalgoPrimitiveSolverSampleTest : PrimitiveSolverSample()

--- a/ojalgo-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITOjalgoSudokuSolverSampleTest.kt
+++ b/ojalgo-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITOjalgoSudokuSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITOjalgoSudokuSolverSampleTest : SudokuSolverSample()

--- a/ojalgo-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITOjalgoTravellingSalesmanSolverSampleTest.kt
+++ b/ojalgo-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITOjalgoTravellingSalesmanSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITOjalgoTravellingSalesmanSolverSampleTest : TravellingSalesmanSolverSample()

--- a/ojalgo-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
+++ b/ojalgo-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
@@ -1,0 +1,3 @@
+package io.github.mohitc.lpsolver.test
+
+class ITSolverTest : SolverTest()

--- a/scip-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITScipKnapsackSolverSampleTest.kt
+++ b/scip-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITScipKnapsackSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITScipKnapsackSolverSampleTest : KnapsackSolverSample()

--- a/scip-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITScipPrimitiveSolverSampleTest.kt
+++ b/scip-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITScipPrimitiveSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITScipPrimitiveSolverSampleTest : PrimitiveSolverSample()

--- a/scip-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITScipSudokuSolverSampleTest.kt
+++ b/scip-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITScipSudokuSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITScipSudokuSolverSampleTest : SudokuSolverSample()

--- a/scip-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITScipTravellingSalesmanSolverSampleTest.kt
+++ b/scip-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/sample/ITScipTravellingSalesmanSolverSampleTest.kt
@@ -1,3 +1,0 @@
-package io.github.mohitc.lpsolver.sample
-
-class ITScipTravellingSalesmanSolverSampleTest : TravellingSalesmanSolverSample()

--- a/scip-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
+++ b/scip-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
@@ -1,0 +1,3 @@
+package io.github.mohitc.lpsolver.test
+
+class ITSolverTest : SolverTest()


### PR DESCRIPTION
LPSolverSample has test instances with assertions to check if the solvers solve the problem correctly. Originally, each model was supported in a different class, which then needed an instantiation in the integration tests for each of the solver implementations. This change creates 
  * SolverTestInstance interface which examples have to implement
  * SolverTest which runs a table driven test on all defined solver instances 

and the SolverTest class is the only class that needs to be replicated across all existing solvers to support integration testing. 

closes #26 