### PR TITLE
Add support for the Mosek Solver

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ solvers:
 * [SCIP](https://www.scipopt.org/)
 * [HIGHS](https://highs.dev)
 * [ojAlgo](https://www.ojalgo.org/)
+* [Mosek](https://www.mosek.com)
 
 ## How it works
 
@@ -127,6 +128,7 @@ The core of the Linear Programming framework is divided into three modules:
   - [scip-solver](scip-solver/README.md)
   - [highs-solver](highs-solver/README.md)
   - [ojalgo-solver](ojalgo-solver/README.md)
+  - [mosek-solver](mosek-solver/README.md)
 * [lp-rw](lp-rw/README.md) implements mechanisms to import/export models and
   computed results to different file formats.
 * For projects that do not have Java bindings available, the project includes

--- a/dev-env-fedora/Dockerfile
+++ b/dev-env-fedora/Dockerfile
@@ -20,9 +20,9 @@ RUN source /etc/bashrc
 
 # Download and install Maven 
 
-RUN wget https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.tar.gz -P /tmp && \
-    tar -zxvf /tmp/apache-maven-3.9.10-bin.tar.gz -C /opt && \
-    ln -s /opt/apache-maven-3.9.10 /opt/maven
+RUN wget https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.tar.gz -P /tmp && \
+    tar -zxvf /tmp/apache-maven-3.9.11-bin.tar.gz -C /opt && \
+    ln -s /opt/apache-maven-3.9.11 /opt/maven
 
 ENV M2_HOME="/opt/maven"
 ENV MAVEN_HOME="/opt/maven"
@@ -70,6 +70,12 @@ RUN cd /opt/ && \
     cd /opt/HiGHS && \
     cmake -S . -B build && \
     cmake --build build
+
+# Download and install Mosek
+
+RUN wget https://download.mosek.com/stable/11.0.25/mosektoolslinux64x86.tar.bz2 -P /tmp && \
+    tar -xvf /tmp/mosektoolslinux64x86.tar.bz2 -C /tmp && \
+    mv /tmp/mosek/11.0 /opt/mosek
 
 # Cleanup downloads
 RUN rm -rf /tmp/*

--- a/dev-env-fedora/README.md
+++ b/dev-env-fedora/README.md
@@ -51,6 +51,7 @@ that includes:
 * GLPK v5.0
 * SCIP Optimization Suite (v9.2.2)
 * HiGHS Solver (v1.11.0)
+* Mosek Solver (v.11.0.25)
 
 In order to build and explore the project, you can navigate to the root folder
 in this project and use the command line below run the docker image, mount the

--- a/mosek-solver/README.md
+++ b/mosek-solver/README.md
@@ -1,0 +1,59 @@
+# Mosek Solver
+
+The Mosek solver converts the programmed model to be solved
+using [Mosek](https://www.mosek.com/). Mosek provides a
+[Java API](https://docs.mosek.com/11.0/javaapi/index.html)
+and the solver converts an
+`LPModel` instance into an equivalent problem instance in the Mosek Java API.
+
+## Installation Instructions
+
+Installation instructions for Mosek can be found on the
+Mosek [website](https://www.mosek.com/downloads/). Mosek is also installed with
+the [docker image](../dev-env-fedora/README.md) used as the development
+environment. Mosek provides instructions for setting up licenses and these need
+to be configured in the docker image in order to run problem instances using
+Mosek. Typically, this can be achieved by using the `--mount` operations for a
+docker image to put the Mosek license in the desired location in the development
+environment and ues that to run the problem instances.
+
+For example, if you want to mount the license file under the root user in the
+docker container, you can update the commands to run the container to
+
+```shell
+$ docker run \
+  --mount type=bind,src=./,dst=/root/projects/LPFramework \
+  --mount type=bind,src={path-to-mosek-license-folder},dst=/root/mosek \
+  -it ghcr.io/mohitc/lpframework/dev-env-fedora:master \
+  /bin/bash
+
+```
+
+## Running Problem instances
+
+The Mosek solver needs the references to the Mosek libraries. In order to run
+the integration tests and other problem instances, the `LD_LIBRARY_PATH` needs
+to be configured to point to these libraries which are located under the
+`tools/platform/{platform_type}/bin` in your installation.
+
+## Running Integration Tests
+
+Sample problem instances based on the [
+`lp-solver-sample`](../lp-solver-sample/README.md) can be run as integration
+tests, and are disabled by default. In order to enable the tests, go to the
+parent pom and set the property:
+
+```xml
+
+<mosek.skiptests>false</mosek.skiptests>
+```
+
+and configure the properties `mosek-root-path`, and if required change the
+platform in the `ld-library-path` property in the POM to point to the correct
+mosek installation and platform name. Once done, run the target
+
+```shell
+$ mvn clean verify
+```
+
+to run the problem instances.

--- a/mosek-solver/pom.xml
+++ b/mosek-solver/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>linear-programming</artifactId>
+    <groupId>io.github.mohitc</groupId>
+    <version>${revision}</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>mosek-solver</artifactId>
+
+  <!-- Module Metadata -->
+  <name>${project.groupId}.${project.artifactId}</name>
+  <description>
+    The implementation of the LPSolver API which uses the MOSEK
+    Solver (https://www.mosek.com) to solve MILP problems.
+  </description>
+
+  <properties>
+    <mosek-root.path>/opt/mosek</mosek-root.path>
+    <ld-library-path>${mosek-root.path}/tools/platform/linux64x86/bin</ld-library-path>
+    <mosek.version>11.1.0</mosek.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.github.mohitc</groupId>
+      <artifactId>lp-solver</artifactId>
+      <version>${revision}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.mosek</groupId>
+      <artifactId>mosek</artifactId>
+      <version>${mosek.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.mohitc</groupId>
+      <artifactId>lp-solver-sample</artifactId>
+      <version>${revision}</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>${build-helper.version}</version>
+        <executions>
+          <!-- Add the integration test directory to the build -->
+          <execution>
+            <id>add-integration-test-sources</id>
+            <phase>generate-test-sources</phase>
+            <goals>
+              <goal>add-test-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>src/integration-test/kotlin</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Failsafe plugin to run integration tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>${failsafe.version}</version>
+        <executions>
+          <execution>
+            <id>integration-tests</id>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+            <configuration>
+              <skipTests>${mosek.skiptests}</skipTests>
+              <!-- Provide environment variables -->
+              <environmentVariables>
+                <LD_LIBRARY_PATH>${ld-library-path}</LD_LIBRARY_PATH>
+              </environmentVariables>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- Surefire plugin to run Junit tests -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${surefire.version}</version>
+        <configuration>
+          <!-- Provide environment variables -->
+          <environmentVariables>
+            <LD_LIBRARY_PATH>${ld-library-path}</LD_LIBRARY_PATH>
+          </environmentVariables>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/mosek-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
+++ b/mosek-solver/src/integration-test/kotlin/io/github/mohitc/lpsolver/test/ITSolverTest.kt
@@ -1,0 +1,3 @@
+package io.github.mohitc.lpsolver.test
+
+class ITSolverTest : SolverTest()

--- a/mosek-solver/src/main/kotlin/io/github/mohitc/lpsolver/mosek/MosekLPSolver.kt
+++ b/mosek-solver/src/main/kotlin/io/github/mohitc/lpsolver/mosek/MosekLPSolver.kt
@@ -1,0 +1,249 @@
+package io.github.mohitc.lpsolver.mosek
+
+import com.mosek.mosek.Stream
+import com.mosek.mosek.Task
+import com.mosek.mosek.boundkey
+import com.mosek.mosek.objsense
+import com.mosek.mosek.solsta
+import com.mosek.mosek.soltype
+import com.mosek.mosek.streamtype
+import com.mosek.mosek.variabletype
+import io.github.mohitc.lpapi.model.LPModel
+import io.github.mohitc.lpapi.model.LPModelResult
+import io.github.mohitc.lpapi.model.enums.LPObjectiveType
+import io.github.mohitc.lpapi.model.enums.LPOperator
+import io.github.mohitc.lpapi.model.enums.LPSolutionStatus
+import io.github.mohitc.lpapi.model.enums.LPVarType
+import io.github.mohitc.lpsolver.LPSolver
+import kotlin.system.measureTimeMillis
+
+class MosekLPSolver(
+  model: LPModel,
+) : LPSolver<Task>(model) {
+  private var baseModel: Task? = null
+
+  private val variableMap: MutableMap<String, Int> = mutableMapOf<String, Int>()
+
+  private val constraintMap: MutableMap<String, Int> = mutableMapOf<String, Int>()
+
+  override fun initModel(): Boolean {
+    try {
+      val task = Task()
+      // route log stream to the slf4j logger
+      task.set_Stream(
+        streamtype.log,
+        object : Stream() {
+          override fun stream(msg: String) = log.info { msg }
+        },
+      )
+      baseModel = task
+    } catch (e: Throwable) {
+      log.error { "Exception while initializing model: $e" }
+      log.debug { e.stackTraceToString() }
+      return false
+    }
+    return true
+  }
+
+  override fun getBaseModel(): Task? = baseModel
+
+  override fun solve(): LPSolutionStatus {
+    try {
+      if (baseModel == null) {
+        log.error("Base model not initialized.")
+        model.solution = LPModelResult(LPSolutionStatus.ERROR)
+        return LPSolutionStatus.ERROR
+      }
+
+      // Solve the problem
+      val executionTime =
+        measureTimeMillis {
+          baseModel!!.optimize()
+        }
+      // Print a summary containing information
+      // about the solution for debugging purposes
+      baseModel!!.solutionsummary(streamtype.msg)
+
+      // Get status information about the solution
+      val mosekStatus = baseModel!!.getsolsta(soltype.itg)
+
+      val solutionStatus = convertSolutionStatus(mosekStatus)
+
+      when (solutionStatus) {
+        LPSolutionStatus.ERROR, LPSolutionStatus.INFEASIBLE, LPSolutionStatus.UNBOUNDED,
+        LPSolutionStatus.INFEASIBLE_OR_UNBOUNDED,
+        ->
+          model.solution = LPModelResult(solutionStatus)
+        else -> {
+          val variableResults = baseModel!!.getxx(soltype.itg)
+          variableMap.forEach {
+            lpVarIdentifier,
+            index,
+            ->
+            model.variables.get(lpVarIdentifier)?.populateResult(variableResults[index])
+          }
+          val objectiveVal = model.evaluate(model.objective.expression)
+          if (objectiveVal == null) {
+            log.error { "evaluate(${model.objective.expression}) want non-null got null" }
+            model.solution = LPModelResult(LPSolutionStatus.ERROR)
+            return LPSolutionStatus.ERROR
+          }
+          model.solution =
+            LPModelResult(
+              solutionStatus,
+              objectiveVal,
+              executionTime,
+              if (solutionStatus == LPSolutionStatus.OPTIMAL) {
+                0.0
+              } else {
+                null
+              },
+            )
+        }
+      }
+      return solutionStatus
+    } catch (e: Throwable) {
+      log.error { "Exception while solving the model: $e" }
+      log.debug { e.stackTraceToString() }
+
+      model.solution = LPModelResult(LPSolutionStatus.ERROR)
+      return LPSolutionStatus.ERROR
+    }
+  }
+
+  fun convertSolutionStatus(status: solsta): LPSolutionStatus =
+    when (status) {
+      solsta.dual_feas -> LPSolutionStatus.CUTOFF
+      solsta.dual_infeas_cer -> LPSolutionStatus.INFEASIBLE
+      solsta.integer_optimal -> LPSolutionStatus.OPTIMAL
+      solsta.optimal -> LPSolutionStatus.OPTIMAL
+      solsta.prim_and_dual_feas -> LPSolutionStatus.CUTOFF
+      solsta.prim_feas -> LPSolutionStatus.CUTOFF
+      solsta.prim_infeas_cer -> LPSolutionStatus.INFEASIBLE
+      solsta.unknown -> LPSolutionStatus.UNKNOWN
+      else -> LPSolutionStatus.UNKNOWN
+    }
+
+  private fun convertVarType(lpVarType: LPVarType): variabletype =
+    when (lpVarType) {
+      LPVarType.BOOLEAN -> variabletype.type_int
+      LPVarType.INTEGER -> variabletype.type_int
+      LPVarType.DOUBLE -> variabletype.type_cont
+    }
+
+  override fun initVars(): Boolean {
+    log.info { "Initializing Variables" }
+    val numVar = model.variables.allValues().size
+    log.info { "Variable Size = $numVar" }
+    var currVarIdentifier = 0
+    try {
+      baseModel?.appendvars(numVar)
+      model.variables.allValues().forEach { lpVar ->
+        log.info { "Initializing variable $lpVar" }
+        baseModel!!.putvarname(currVarIdentifier, lpVar.identifier)
+        baseModel!!.putvarbound(currVarIdentifier, boundkey.ra, lpVar.lbound, lpVar.ubound)
+        baseModel!!.putvartype(currVarIdentifier, convertVarType(lpVar.type))
+        variableMap[lpVar.identifier] = currVarIdentifier
+        currVarIdentifier++
+      }
+    } catch (e: Throwable) {
+      log.error { "Error while initializing variables: $e" }
+      log.debug { e.stackTraceToString() }
+      return false
+    }
+    return true
+  }
+
+  override fun initConstraints(): Boolean {
+    val numConstraints = model.constraints.allValues().size
+    // we need to store the contribution of a variable to a constraint for initializing
+    // the mosek model. In the first pass, we store the contributions as a pair of Int
+    // (constraint identifier) and the contribution (double) for each variable, and once
+    // all constraints are mapped to an identifier, we set the bounds in the mosek model.
+    val varContributions = mutableMapOf<String, MutableList<Pair<Int, Double>>>()
+    var currentConstraintIdentifier = 0
+    try {
+      baseModel?.appendcons(numConstraints)
+      model.constraints.allValues().forEach { lPConstraint ->
+        log.debug { "Initializing constraint: $lPConstraint" }
+        val reducedConstraint = model.reduce(lPConstraint)
+        if (reducedConstraint == null) {
+          log.error { "empty value while reducing constraint $lPConstraint" }
+          return false
+        }
+        constraintMap[lPConstraint.identifier] = currentConstraintIdentifier
+        reducedConstraint.lhs.expression.forEach { t ->
+          if (t.isConstant()) {
+            log.error { "Constant term not expected in the LHS of a reduced constraint $reducedConstraint" }
+            return false
+          }
+          if (varContributions[t.lpVarIdentifier!!] == null) {
+            varContributions[t.lpVarIdentifier!!] = mutableListOf()
+          }
+          // Initialize variable contributions for each term in the constraint
+          varContributions[t.lpVarIdentifier]!!.add(Pair(currentConstraintIdentifier, t.coefficient!!))
+        }
+        val value =
+          reducedConstraint.rhs.expression
+            .filter { t ->
+              t.isConstant()
+            }.map { t -> t.coefficient }
+            .firstOrNull() ?: 0.0
+        when (reducedConstraint.operator) {
+          LPOperator.EQUAL -> baseModel!!.putconbound(currentConstraintIdentifier, boundkey.fx, value, value)
+          LPOperator.LESS_EQUAL -> baseModel!!.putconbound(currentConstraintIdentifier, boundkey.up, 0.0, value)
+          LPOperator.GREATER_EQUAL -> baseModel!!.putconbound(currentConstraintIdentifier, boundkey.lo, value, 0.0)
+        }
+        currentConstraintIdentifier++
+      }
+      log.info { "Variable Map: $variableMap" }
+      log.info { "Variable Contributions: $varContributions" }
+      // Initialize all variable contributions
+      varContributions.forEach { varIdentifier, coeffList ->
+        baseModel!!.putacol(
+          variableMap[varIdentifier]!!,
+          coeffList
+            .map { t ->
+              t.first
+            }.toIntArray(),
+          coeffList.map { t -> t.second }.toDoubleArray(),
+        )
+      }
+    } catch (e: Throwable) {
+      log.error { "Error while initializing constraints: $e" }
+      log.debug { e.stackTraceToString() }
+      return false
+    }
+    return true
+  }
+
+  private fun getObjectiveSense(obj: LPObjectiveType): objsense =
+    when (obj) {
+      LPObjectiveType.MAXIMIZE -> objsense.maximize
+      LPObjectiveType.MINIMIZE -> objsense.minimize
+    }
+
+  override fun initObjectiveFunction(): Boolean {
+    try {
+      val reducedObjective =
+        model
+          .reduce(model.objective.expression)
+      reducedObjective?.expression?.forEach { t ->
+        if (t.isConstant()) {
+          log.debug {
+            "Constant terms are not supported in mosek model. Will include them in the " + "" +
+              "recalculation of the objective value calculation only"
+          }
+        } else {
+          baseModel!!.putcj(variableMap[t.lpVarIdentifier]!!, t.coefficient!!)
+        }
+      }
+      baseModel!!.putobjsense(getObjectiveSense(model.objective.objective))
+    } catch (e: Throwable) {
+      log.error { "Error while initializing objective function: $e" }
+      log.debug { e.stackTraceToString() }
+      return false
+    }
+    return true
+  }
+}

--- a/mosek-solver/src/main/kotlin/io/github/mohitc/lpsolver/spi/mosek/MosekLPSpi.kt
+++ b/mosek-solver/src/main/kotlin/io/github/mohitc/lpsolver/spi/mosek/MosekLPSpi.kt
@@ -1,0 +1,11 @@
+package io.github.mohitc.lpsolver.spi.mosek
+
+import com.mosek.mosek.Task
+import io.github.mohitc.lpapi.model.LPModel
+import io.github.mohitc.lpsolver.LPSolver
+import io.github.mohitc.lpsolver.mosek.MosekLPSolver
+import io.github.mohitc.lpsolver.spi.LPSpi
+
+class MosekLPSpi : LPSpi<Task> {
+  override fun create(model: LPModel): LPSolver<Task> = MosekLPSolver(model)
+}

--- a/mosek-solver/src/main/resources/META-INF/services/io.github.mohitc.lpsolver.spi.LPSpi
+++ b/mosek-solver/src/main/resources/META-INF/services/io.github.mohitc.lpsolver.spi.LPSpi
@@ -1,0 +1,1 @@
+io.github.mohitc.lpsolver.spi.mosek.MosekLPSpi

--- a/mosek-solver/src/test/kotlin/io/github/mohitc/lpsolver/mosek/MosekLPSolverTest.kt
+++ b/mosek-solver/src/test/kotlin/io/github/mohitc/lpsolver/mosek/MosekLPSolverTest.kt
@@ -1,0 +1,537 @@
+package io.github.mohitc.lpsolver.mosek
+
+import com.mosek.mosek.Task
+import com.mosek.mosek.boundkey
+import com.mosek.mosek.objsense
+import com.mosek.mosek.solsta
+import com.mosek.mosek.soltype
+import com.mosek.mosek.variabletype
+import io.github.mohitc.lpapi.model.LPConstraint
+import io.github.mohitc.lpapi.model.LPExpression
+import io.github.mohitc.lpapi.model.LPModel
+import io.github.mohitc.lpapi.model.LPVar
+import io.github.mohitc.lpapi.model.enums.LPObjectiveType
+import io.github.mohitc.lpapi.model.enums.LPOperator
+import io.github.mohitc.lpapi.model.enums.LPSolutionStatus
+import io.github.mohitc.lpapi.model.enums.LPVarType
+import mu.KotlinLogging
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.mock
+import java.util.stream.Stream
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class MosekLPSolverTest {
+  private val log = KotlinLogging.logger { this.javaClass.name }
+
+  private fun setParameter(
+    solver: MosekLPSolver,
+    field: String,
+    value: Any?,
+  ) {
+    solver.javaClass.getDeclaredField(field).let {
+      it.isAccessible = true
+      it.set(solver, value)
+    }
+  }
+
+  private fun setModel(
+    solver: MosekLPSolver,
+    model: Task?,
+  ) = setParameter(solver, "baseModel", model)
+
+  private fun setVariableMap(
+    solver: MosekLPSolver,
+    variableMap: MutableMap<String, Int>,
+  ) = setParameter(solver, "variableMap", variableMap)
+
+  private fun setConstraintMap(
+    solver: MosekLPSolver,
+    constraintMap: MutableMap<String, Int>,
+  ) = setParameter(solver, "constraintMap", constraintMap)
+
+  private fun argsForInitVars() =
+    Stream.of(
+      Arguments.of(
+        "Exception while initializing variable columns",
+        mock<Task> {
+          on { appendvars(1) }.thenThrow(RuntimeException("Error"))
+        },
+        LPVar("X", LPVarType.BOOLEAN),
+        false,
+        mutableMapOf<String, Int>(),
+      ),
+      Arguments.of(
+        "Exception while initializing variable name",
+        mock<Task> {
+          on { putvarname(0, "X") }.thenThrow(RuntimeException("Error"))
+        },
+        LPVar("X", LPVarType.BOOLEAN),
+        false,
+        mutableMapOf<String, Int>(),
+      ),
+      Arguments.of(
+        "Exception while initializing variable bounds",
+        mock<Task> {
+          on { putvarbound(0, boundkey.ra, 0.0, 1.0) }.thenThrow(RuntimeException("Error"))
+        },
+        LPVar("X", LPVarType.BOOLEAN),
+        false,
+        mutableMapOf<String, Int>(),
+      ),
+      Arguments.of(
+        "Exception while initializing variable type",
+        mock<Task> {
+          on { putvartype(0, variabletype.type_int) }.thenThrow(RuntimeException("Error"))
+        },
+        LPVar("X", LPVarType.BOOLEAN),
+        false,
+        mutableMapOf<String, Int>(),
+      ),
+      Arguments.of(
+        "Correctly Initialize a continuous variable",
+        mock<Task> {
+          on { putvartype(0, variabletype.type_int) }.thenThrow(RuntimeException("Error"))
+        },
+        LPVar("X", LPVarType.DOUBLE, 1.0, 3.0),
+        true,
+        mutableMapOf(Pair("X", 0)),
+      ),
+      Arguments.of(
+        "Correctly Initialize an integer variable",
+        mock<Task> {
+          on { putvartype(0, variabletype.type_cont) }.thenThrow(RuntimeException("Error"))
+        },
+        LPVar("X", LPVarType.INTEGER, 1.0, 3.0),
+        true,
+        mutableMapOf(Pair("X", 0)),
+      ),
+      Arguments.of(
+        "Correctly Initialize a boolean variable",
+        mock<Task> {
+          on { putvartype(0, variabletype.type_cont) }.thenThrow(RuntimeException("Error"))
+        },
+        LPVar("X", LPVarType.INTEGER, 1.0, 3.0),
+        true,
+        mutableMapOf(Pair("X", 0)),
+      ),
+    )
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("argsForInitVars")
+  fun testInitVars(
+    desc: String,
+    mosekModel: Task,
+    lpVar: LPVar,
+    wantSuccess: Boolean,
+    wantVarMap: Map<String, Int>,
+  ) {
+    log.info { "Test case: $desc" }
+    val lpModel = LPModel("test").apply { this.variables.add(lpVar) }
+    val solver = MosekLPSolver(lpModel)
+    setModel(solver, mosekModel)
+    val gotVarMap =
+      mutableMapOf<String, Int>().apply {
+        setVariableMap(solver, this)
+      }
+    val gotSuccess = solver.initVars()
+    assertEquals(wantSuccess, gotSuccess, "solver.initVars() want $wantSuccess got $gotSuccess")
+    assertEquals(wantVarMap, gotVarMap, "VariableMap want=$wantVarMap, got=$gotVarMap")
+  }
+
+  private fun argsForInitConstraints() =
+    Stream.of(
+      Arguments.of(
+        "Error while initializing constraints",
+        LPModel("test").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.BOOLEAN))
+          this.constraints.add(
+            LPConstraint(
+              "x+y=1",
+              LPExpression().addTerm("x").addTerm("y"),
+              LPOperator.EQUAL,
+              LPExpression().add(1),
+            ),
+          )
+        },
+        mock<Task> {
+          on { appendcons(1) }.thenThrow(RuntimeException("error"))
+        },
+        mutableMapOf(Pair("x", 0), Pair("y", 1)),
+        false,
+        mutableMapOf<String, Int>(),
+      ),
+      Arguments.of(
+        "Error while applying equality",
+        LPModel("test").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.BOOLEAN))
+          this.constraints.add(
+            LPConstraint(
+              "x+y=1",
+              LPExpression().addTerm("x").addTerm("y"),
+              LPOperator.EQUAL,
+              LPExpression().add(1),
+            ),
+          )
+        },
+        mock<Task> {
+          on { putconbound(0, boundkey.fx, 1.0, 1.0) }.thenThrow(RuntimeException("error"))
+        },
+        mutableMapOf(Pair("x", 0), Pair("y", 1)),
+        false,
+        mutableMapOf<String, Int>(),
+      ),
+      Arguments.of(
+        "Error while applying <= operator",
+        LPModel("test").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.BOOLEAN))
+          this.constraints.add(
+            LPConstraint(
+              "x+y<=1",
+              LPExpression().addTerm("x").addTerm("y"),
+              LPOperator.LESS_EQUAL,
+              LPExpression().add(1),
+            ),
+          )
+        },
+        mock<Task> {
+          on { putconbound(0, boundkey.up, 0.0, 1.0) }.thenThrow(RuntimeException("error"))
+        },
+        mutableMapOf(Pair("x", 0), Pair("y", 1)),
+        false,
+        mutableMapOf<String, Int>(),
+      ),
+      Arguments.of(
+        "Error while applying >= operator",
+        LPModel("test").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.BOOLEAN))
+          this.constraints.add(
+            LPConstraint(
+              "x+y>=1",
+              LPExpression().addTerm("x").addTerm("y"),
+              LPOperator.GREATER_EQUAL,
+              LPExpression().add(1),
+            ),
+          )
+        },
+        mock<Task> {
+          on { putconbound(0, boundkey.lo, 1.0, 0.0) }.thenThrow(RuntimeException("error"))
+        },
+        mutableMapOf(Pair("x", 0), Pair("y", 1)),
+        false,
+        mutableMapOf<String, Int>(),
+      ),
+      Arguments.of(
+        "Error while initializing var contributions (x)",
+        LPModel("test").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.BOOLEAN))
+          this.constraints.add(
+            LPConstraint(
+              "2x-y>=1",
+              LPExpression().addTerm(2.0, "x").addTerm(-1.0, "y"),
+              LPOperator.GREATER_EQUAL,
+              LPExpression().add(1),
+            ),
+          )
+        },
+        mock<Task> {
+          on { putacol(0, IntArray(1) { 0 }, DoubleArray(1) { 2.0 }) }.thenThrow(RuntimeException("error"))
+        },
+        mutableMapOf(Pair("x", 0), Pair("y", 1)),
+        false,
+        mutableMapOf<String, Int>(),
+      ),
+      Arguments.of(
+        "Error while initializing var contributions (y)",
+        LPModel("test").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.BOOLEAN))
+          this.constraints.add(
+            LPConstraint(
+              "2x-y>=1",
+              LPExpression().addTerm("x").addTerm("x").addTerm(-1.0, "y"),
+              LPOperator.GREATER_EQUAL,
+              LPExpression().add(1),
+            ),
+          )
+        },
+        mock<Task> {
+          on { putacol(1, IntArray(1) { 0 }, DoubleArray(1) { -1.0 }) }.thenThrow(RuntimeException("error"))
+        },
+        mutableMapOf(Pair("x", 0), Pair("y", 1)),
+        false,
+        mutableMapOf<String, Int>(),
+      ),
+      Arguments.of(
+        "Success Initializing Constraints",
+        LPModel("test").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.BOOLEAN))
+          this.constraints.add(
+            LPConstraint(
+              "2x-y>=1",
+              LPExpression().addTerm("x").addTerm("x").addTerm(-1.0, "y"),
+              LPOperator.GREATER_EQUAL,
+              LPExpression().add(1),
+            ),
+          )
+        },
+        mock<Task> {},
+        mutableMapOf(Pair("x", 0), Pair("y", 1)),
+        true,
+        mutableMapOf(Pair("2x-y>=1", 0)),
+      ),
+    )
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("argsForInitConstraints")
+  fun testInitConstraints(
+    desc: String,
+    lpModel: LPModel,
+    model: Task,
+    variableMap: MutableMap<String, Int>,
+    wantSuccess: Boolean,
+    wantConstraintMap: Map<String, Int>,
+  ) {
+    log.info("Test Case: $desc")
+    val solver = MosekLPSolver(lpModel)
+    setModel(solver, model)
+    setVariableMap(solver, variableMap)
+    val gotConstraintMap =
+      mutableMapOf<String, Int>().apply {
+        setConstraintMap(solver, this)
+      }
+    val gotSuccess = solver.initConstraints()
+    assertEquals(
+      wantSuccess,
+      gotSuccess,
+      "initConstraints() want $wantSuccess got $gotSuccess",
+    )
+    if (wantSuccess) {
+      assertEquals(
+        wantConstraintMap,
+        gotConstraintMap,
+        "initConstraints() want $wantConstraintMap got $gotConstraintMap",
+      )
+    }
+  }
+
+  private fun argsForInitObjective() =
+    Stream.of(
+      Arguments.of(
+        "Error while initializing the value of a specific variable",
+        LPModel("MAX x+2y+3z+4").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("z", LPVarType.BOOLEAN))
+          this.objective.objective = LPObjectiveType.MAXIMIZE
+          this.objective.expression
+            .addTerm("x")
+            .addTerm("y")
+            .addTerm("y")
+            .addTerm(3, "z")
+            .add(4)
+        },
+        mock<Task> {
+          on { putcj(0, 1.0) }.thenThrow(RuntimeException("Error"))
+        },
+        mutableMapOf(
+          Pair("x", 0),
+          Pair("y", 1),
+          Pair("z", 2),
+        ),
+        false,
+      ),
+      Arguments.of(
+        "Error while initializing the value of a specific variable (y)",
+        LPModel("MAX x+2y+3z+4").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("z", LPVarType.BOOLEAN))
+          this.objective.objective = LPObjectiveType.MAXIMIZE
+          this.objective.expression
+            .addTerm("x")
+            .addTerm("y")
+            .addTerm("y")
+            .addTerm(3, "z")
+            .add(4)
+        },
+        mock<Task> {
+          on { putcj(1, 2.0) }.thenThrow(RuntimeException("Error"))
+        },
+        mutableMapOf(
+          Pair("x", 0),
+          Pair("y", 1),
+          Pair("z", 2),
+        ),
+        false,
+      ),
+      Arguments.of(
+        "Error while configuring the objective sense",
+        LPModel("MAX x+2y+3z+4").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("z", LPVarType.BOOLEAN))
+          this.objective.objective = LPObjectiveType.MAXIMIZE
+          this.objective.expression
+            .addTerm("x")
+            .addTerm("y")
+            .addTerm("y")
+            .addTerm(3, "z")
+            .add(4)
+        },
+        mock<Task> {
+          on { putobjsense(objsense.maximize) }.thenThrow(RuntimeException("Error"))
+        },
+        mutableMapOf(
+          Pair("x", 0),
+          Pair("y", 1),
+          Pair("z", 2),
+        ),
+        false,
+      ),
+      Arguments.of(
+        "Successful initialization",
+        LPModel("MIN x+2y+3z+4").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("z", LPVarType.BOOLEAN))
+          this.objective.objective = LPObjectiveType.MINIMIZE
+          this.objective.expression
+            .addTerm("x")
+            .addTerm("y")
+            .addTerm("y")
+            .addTerm(3, "z")
+            .add(4)
+        },
+        mock<Task> {
+          on { putobjsense(objsense.maximize) }.thenThrow(RuntimeException("Error"))
+        },
+        mutableMapOf(
+          Pair("x", 0),
+          Pair("y", 1),
+          Pair("z", 2),
+        ),
+        true,
+      ),
+    )
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("argsForInitObjective")
+  fun testInitObjective(
+    desc: String,
+    lpModel: LPModel,
+    model: Task,
+    variableMap: MutableMap<String, Int>,
+    wantSuccess: Boolean,
+  ) {
+    log.info("Test Case: $desc")
+    val solver = MosekLPSolver(lpModel)
+    setModel(solver, model)
+    setVariableMap(solver, variableMap)
+    val gotSuccess = solver.initObjectiveFunction()
+    assertEquals(wantSuccess, gotSuccess, "initObjectiveFunction() want $wantSuccess got $gotSuccess")
+  }
+
+  fun argsForSolve() =
+    Stream.of(
+      Arguments.of(
+        "Error during optimize call",
+        LPModel("test").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.INTEGER, 0.0, 10.0))
+          this.variables.add(LPVar("z", LPVarType.DOUBLE, 1.0, 2.0))
+          this.objective.expression
+            .addTerm("x")
+            .addTerm(2, "y")
+            .addTerm(3, "z")
+            .add(4)
+        },
+        mock<Task> {
+          on { optimize() }.thenThrow(RuntimeException("error"))
+        },
+        mutableMapOf(
+          Pair("x", 0),
+          Pair("y", 1),
+          Pair("z", 2),
+        ),
+        LPSolutionStatus.ERROR,
+        mutableMapOf<String, Number>(),
+        0.0,
+      ),
+      Arguments.of(
+        "Extract Results",
+        LPModel("test").apply {
+          this.variables.add(LPVar("x", LPVarType.BOOLEAN))
+          this.variables.add(LPVar("y", LPVarType.INTEGER, 0.0, 10.0))
+          this.variables.add(LPVar("z", LPVarType.DOUBLE, 1.0, 2.0))
+          this.objective.expression
+            .addTerm("x")
+            .addTerm(2, "y")
+            .addTerm(3, "z")
+            .add(4)
+        },
+        mock<Task> {
+          on { getsolsta(soltype.itg) }.thenReturn(solsta.integer_optimal)
+          on { getxx(soltype.itg) }.thenReturn(arrayOf(1.0, 2.1, 1.5).toDoubleArray())
+        },
+        mutableMapOf(
+          Pair("x", 0),
+          Pair("y", 1),
+          Pair("z", 2),
+        ),
+        LPSolutionStatus.OPTIMAL,
+        mutableMapOf<String, Number>(
+          Pair("x", 1),
+          Pair("y", 2),
+          Pair("z", 1.5),
+        ),
+        13.5,
+      ),
+    )
+
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("argsForSolve")
+  fun testSolve(
+    desc: String,
+    lpModel: LPModel,
+    model: Task,
+    variableMap: MutableMap<String, Int>,
+    wantStatus: LPSolutionStatus,
+    wantVarResult: Map<String, Number>,
+    wantObjectiveVal: Double,
+  ) {
+    log.info("Test Case: $desc")
+    val solver = MosekLPSolver(lpModel)
+    setModel(solver, model)
+    setVariableMap(solver, variableMap)
+    val gotStatus = solver.solve()
+    assertEquals(wantStatus, gotStatus, "solve() want $wantStatus got $gotStatus")
+    if (wantStatus == LPSolutionStatus.OPTIMAL) {
+      lpModel.variables.allValues().forEach { lpvar ->
+        assertTrue(lpvar.resultSet, "${lpvar.resultSet} want true got false")
+      }
+      val gotVarResult =
+        lpModel.variables
+          .allValues()
+          .associate { lpVar ->
+            Pair(lpVar.identifier, lpVar.result)
+          }
+      assertEquals(wantVarResult, gotVarResult, "results want $wantVarResult got $gotVarResult")
+      val gotObjectiveValue = lpModel.solution!!.objective!!
+      assertTrue(
+        Math.abs(wantObjectiveVal - gotObjectiveValue) < 0.01,
+        "objcetive value want $wantObjectiveVal got $gotObjectiveValue",
+      )
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <module>highs-ffm</module>
         <module>highs-solver</module>
         <module>lp-solver-sample</module>
+        <module>mosek-solver</module>
         <module>scip-solver</module>
         <module>scip-ffm</module>
         <module>lp-rw</module>
@@ -89,6 +90,7 @@
     <scip-ffm.skiptests>false</scip-ffm.skiptests>
     <highs.skiptests>false</highs.skiptests>
     <highs-ffm.skiptests>false</highs-ffm.skiptests>
+    <mosek.skiptests>true</mosek.skiptests>
     <cplex.skiptests>true</cplex.skiptests>
     <gurobi.skiptests>true</gurobi.skiptests>
     <ojalgo.skiptests>false</ojalgo.skiptests>


### PR DESCRIPTION
Implements support for creating a solver instance using the Mosek Java API, and includes the Mosek installation in the Docker container. closes #19 As part of the fixes also bumps up the Maven version to 3.9.11