### PR TITLE
Incorporate GPG signing actions in preparation for publishing to Maven Central

### DIFF
--- a/.github/actions/setup-gpg/action.yaml
+++ b/.github/actions/setup-gpg/action.yaml
@@ -12,7 +12,7 @@ runs:
     # Install gpg secret key in the environment as a pre-requisite for deployment
     - name: 'Setup GPG Key'
       run: |
-        echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --import_options import-show --import
+        echo -n "$GPG_SIGNING_KEY" | base64 --decode | gpg --batch --import-options import-show --import
       env:
         $GPG_SIGNING_KEY: ${{ inputs.gpgKey }}
       shell: bash


### PR DESCRIPTION
Maven central required GPG signatures for the packages that should be published, and this pull request

  * Sets up GPG keys as part of the publishing process to generate GPG signatures. 
  * Updates the profiles to have separate profiles for central and Github publishing, limiting the GPG signing to central publishing only 
  * Sets up workflows to perform cleanup actions post changes. 

With these changes the workspace is missing the actual coordinates of maven central but should otherwise be ready for publishing to central. 