### PR TITLE
Update to Fedora 43, JExtract 25 and Temurin JVM25 

### DIFF
--- a/dev-env-fedora/Dockerfile
+++ b/dev-env-fedora/Dockerfile
@@ -1,5 +1,5 @@
-# Start from Fedora 42
-FROM fedora:42
+# Start from Fedora 43
+FROM fedora:43
 
 # Copy maven settings.xml
 COPY settings.xml /root/.m2/settings.xml
@@ -8,7 +8,7 @@ COPY settings.xml /root/.m2/settings.xml
 COPY adoptium.repo /etc/yum.repos.d/adoptium.repo
 
 # Install java and some common packages and update dependencies from image
-RUN dnf install --setopt=install_weak_deps=False temurin-24-jdk wget git gcc g++ awk -y && \
+RUN dnf install --setopt=install_weak_deps=False temurin-25-jdk wget git gcc g++ awk -y && \
     dnf update -y
 
 # Java Home configuration 
@@ -44,9 +44,9 @@ ENV CFLAGS=""
 ENV LD_LIBRARY_PATH="/usr/local/lib"
 
 # Download and install jextract
-RUN wget https://download.java.net/java/early_access/jextract/22/6/openjdk-22-jextract+6-47_linux-x64_bin.tar.gz -P /tmp && \
-    tar -zxvf /tmp/openjdk-22-jextract+6-47_linux-x64_bin.tar.gz -C /opt && \
-    ln -s /opt/jextract-22 /opt/jextract
+RUN wget https://download.java.net/java/early_access/jextract/25/2/openjdk-25-jextract+2-4_linux-x64_bin.tar.gz -P /tmp && \
+    tar -zxvf /tmp/openjdk-25-jextract+2-4_linux-x64_bin.tar.gz -C /opt && \
+    ln -s /opt/jextract-25 /opt/jextract
 
 ENV PATH="/opt/jextract/bin:$PATH"
 

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kotlin.code.style>official</kotlin.code.style>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
-    <java.version>23</java.version>
+    <java.version>24</java.version>
     <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
     <kotlin.version>2.2.21</kotlin.version>
     <logger.version>3.0.5</logger.version>


### PR DESCRIPTION
Update docker image to use:
  * Fedora 43 Image
  * Jextract 25
  * Temurin JVM 25

Kotlin currently does not support Java 25 bytecode, so target version in the POM will be updated once the kotlin support is available.